### PR TITLE
Add SVM support for QAT compression

### DIFF
--- a/src/common/compression_qat.c
+++ b/src/common/compression_qat.c
@@ -27,6 +27,7 @@
 struct deflate_ctx {
 	CpaInstanceHandle	dc_inst_hdl;
 	CpaDcSessionHandle	session_hdl;
+	CpaInstanceInfo2	inst_info;
 
 	CpaBufferList		**inter_bufs;
 	Cpa16U			num_inter_bufs;
@@ -59,8 +60,8 @@ deflate_init(void **daos_dc_ctx, uint16_t level,
 
 	rc = qat_dc_init(
 		&ctx->dc_inst_hdl, &ctx->session_hdl,
-		&ctx->num_inter_bufs, &ctx->inter_bufs,
-		max_buf_size,
+		&ctx->inst_info, &ctx->num_inter_bufs,
+		&ctx->inter_bufs, max_buf_size,
 		qat_dc_level[dc_level_index]);
 
 	*daos_dc_ctx = ctx;
@@ -76,6 +77,7 @@ deflate_compress(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	return qat_dc_compress(
 		&ctx->dc_inst_hdl,
 		&ctx->session_hdl,
+		&ctx->inst_info,
 		src, src_len,
 		dst, dst_len, produced, DIR_COMPRESS);
 }
@@ -89,6 +91,7 @@ deflate_decompress(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	return qat_dc_compress(
 		&ctx->dc_inst_hdl,
 		&ctx->session_hdl,
+		&ctx->inst_info,
 		src, src_len,
 		dst, dst_len, produced, DIR_DECOMPRESS);
 }
@@ -103,6 +106,7 @@ deflate_compress_async(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	return qat_dc_compress_async(
 		&ctx->dc_inst_hdl,
 		&ctx->session_hdl,
+		&ctx->inst_info,
 		src, src_len,
 		dst, dst_len, DIR_COMPRESS,
 		cb_fn, cb_data);
@@ -118,6 +122,7 @@ deflate_decompress_async(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	return qat_dc_compress_async(
 		&ctx->dc_inst_hdl,
 		&ctx->session_hdl,
+		&ctx->inst_info,
 		src, src_len,
 		dst, dst_len, DIR_DECOMPRESS,
 		cb_fn, cb_data);

--- a/src/include/daos/qat.h
+++ b/src/include/daos/qat.h
@@ -26,6 +26,7 @@ qat_dc_is_available();
 int
 qat_dc_init(CpaInstanceHandle *dcInstHandle,
 	    CpaDcSessionHandle *sessionHdl,
+	    CpaInstanceInfo2 *inst_info,
 	    Cpa16U *numInterBuffLists,
 	    CpaBufferList ***bufferInterArrayPtr,
 	    Cpa32U maxBufferSize,
@@ -34,6 +35,7 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 int
 qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 		CpaDcSessionHandle *sessionHdl,
+		CpaInstanceInfo2 *inst_info,
 		uint8_t *src,
 		size_t srcLen,
 		uint8_t *dst,
@@ -44,6 +46,7 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 int qat_dc_compress_async(
 		CpaInstanceHandle *dcInstHandle,
 		CpaDcSessionHandle *sessionHdl,
+		CpaInstanceInfo2 *inst_info,
 		uint8_t *src,
 		size_t srcLen,
 		uint8_t *dst,


### PR DESCRIPTION
* Add SVM(Shared Virtual Memory) support for QAT compression
* Fix the issue of repeatedly starting and stopping QAT devices
  under multi-thread mode.

Signed-off-by: Chengfei Zhu <chengfei.zhu@intel.com>